### PR TITLE
Fix segfault after initialization failure

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,12 +67,11 @@ int main(int argc, char** argv) {
   rendering::Renderer renderer(engine);
   rendering::UI ui(engine);
 
-  if (!windowHandler.createMainWindow()) {
+  if (!windowHandler.createMainWindow() ||
+      !renderer.init() ||
+      !ui.init()) {
     engine.stop();
-  } else if (!renderer.init()) {
-    engine.stop();
-  } else if (!ui.init()) {
-    engine.stop();
+    return 1;
   }
 
   engine.init(windowHandler, renderer, ui);


### PR DESCRIPTION
Execution should be discontinued if one of the init functions fail.